### PR TITLE
Use --force for `git lfs install --local` to bypass errors associated with differing git-lfs versions

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -732,7 +732,7 @@ class GitCommandManager {
     }
     lfsInstall() {
         return __awaiter(this, void 0, void 0, function* () {
-            yield this.execGit(['lfs', 'install', '--local']);
+            yield this.execGit(['lfs', 'install', '--local', '--force']);
         });
     }
     log1(format) {

--- a/src/git-command-manager.ts
+++ b/src/git-command-manager.ts
@@ -350,7 +350,9 @@ class GitCommandManager {
   }
 
   async lfsInstall(): Promise<void> {
-    await this.execGit(['lfs', 'install', '--local'])
+    // https://github.com/actions/checkout/issues/1476
+    // we use force to bypass errors with differing git-lfs versions
+    await this.execGit(['lfs', 'install', '--local', '--force'])
   }
 
   async log1(format?: string): Promise<string> {


### PR DESCRIPTION
if you host your own CI runner and run this command with differing git-lfs versions , you run into errors